### PR TITLE
changed boolean to s for proposal accepted

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -35,12 +35,23 @@ class ProposalsController < ApplicationController
 
   def update
     @proposal.update(proposal_params)
-    @proposal.project.update accepted: true
-    @message = Message.create(user: current_user, proposal: @proposal, content: "The proposal has been accepted by #{current_user.firstname}, Congratulations from the Helper team!")
-     ProposalChatChannel.broadcast_to(
+    if @proposal.accepted == "accepted"
+      @proposal.project.update(accepted: true)
+      @message = Message.create(user: current_user, proposal: @proposal, content: "The proposal has been accepted by #{current_user.firstname}, Congratulations from the Helper team!")
+      ProposalChatChannel.broadcast_to(
         @proposal,
         render_to_string(partial: "messages/message", locals: { message: @message })
         )
+    elsif @proposal.accepted == "pending"
+      @proposal.project.update(accepted: false)
+    else
+      @proposal.project.update(accepted: false)
+      @message = Message.create(user: current_user, proposal: @proposal, content: "Proposal denied")
+      ProposalChatChannel.broadcast_to(
+        @proposal,
+        render_to_string(partial: "messages/message", locals: { message: @message })
+        )
+    end
   end
 
   def destroy

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -46,7 +46,7 @@
         <% end %>
       </div>
         <%= simple_form_for @proposal do |f| %>
-        <%= f.input :accepted, as: :radio_buttons, label: "Accept the offer"%>
+        <%= f.input :accepted, label: "Change the status of this offer", collection: ["accepted", "denied", "pending"]%>
         <%= f.submit "Confirm" %>
         <% end %>
     </div>

--- a/db/migrate/20201202213218_change_accepted_to_string.rb
+++ b/db/migrate/20201202213218_change_accepted_to_string.rb
@@ -1,0 +1,6 @@
+class ChangeAcceptedToString < ActiveRecord::Migration[6.0]
+  def change
+    change_column :proposals, :accepted, :string
+    change_column_default :proposals, :accepted, "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_02_170231) do
+ActiveRecord::Schema.define(version: 2020_12_02_213218) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2020_12_02_170231) do
     t.text "pitch"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "accepted", default: false
+    t.string "accepted", default: "pending"
     t.index ["project_id"], name: "index_proposals_on_project_id"
     t.index ["user_id"], name: "index_proposals_on_user_id"
   end


### PR DESCRIPTION
Proposal accepted: changed to string
Proposal update can change between pending, accepted or denied
When proposal is set to accepted the project accepted turn to true
When proposal is set to denied the project stays on accepted: false so the projects index display logic should stay functional
